### PR TITLE
Fix bug with CDC status by latitude/longitude

### DIFF
--- a/pyflunearyou/cdc.py
+++ b/pyflunearyou/cdc.py
@@ -54,7 +54,7 @@ class CdcReport:  # pylint: disable=too-few-public-methods
             if key == self._contained_by_id:
                 info = data[keys[idx + 1]]
 
-        return info
+        return adjust_status(info)
 
     async def status_by_state(self, state: str) -> dict:
         """Return the CDC status for the specified state."""

--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -30,8 +30,8 @@ async def test_status(
         info = await client.cdc_reports.status()
 
         assert info == {
-            "level": "3",
-            "level2": None,
+            "level": "Low",
+            "level2": "None",
             "week_date": "2018-10-13",
             "name": "California",
             "fill": {


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes a bug wherein `client.cdc_reports.status()` (i.e., CDC status by client latitude and longitude) would return an integer, rather than a human-friendly string (e.g., "Low").

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
