### PR TITLE
Add support for extended data on user endpoint

### DIFF
--- a/example.py
+++ b/example.py
@@ -9,6 +9,11 @@ from pyflunearyou.errors import FluNearYouError
 
 _LOGGER = logging.getLogger()
 
+LATITUDE = 47.6129432
+LONGITUDE = -122.4821475
+STATE = 'North Dakota'
+ZIP_CODE = '98110'
+
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
@@ -20,23 +25,27 @@ async def main() -> None:
 
             # Get user data for the client's latitude/longitude:
             user_coord_resp = await client.user_reports.status_by_coordinates(
-                47.6129432, -122.4821475)
+                LATITUDE, LONGITUDE)
             _LOGGER.info(
-                'User data by latitude/longitude: %s', user_coord_resp)
+                'User data by latitude/longitude (%s, %s): %s', LATITUDE,
+                LONGITUDE, user_coord_resp)
 
             # Get user data for the a specific ZIP code:
-            user_zip_resp = await client.user_reports.status_by_zip("90046")
-            _LOGGER.info('User data by ZIP code: %s', user_zip_resp)
+            user_zip_resp = await client.user_reports.status_by_zip(ZIP_CODE)
+            _LOGGER.info(
+                'User data by ZIP code (%s): %s', ZIP_CODE, user_zip_resp)
 
             # Get CDC data for the client's latitude/longitude:
             cdc_coord_resp = await client.cdc_reports.status_by_coordinates(
-                47.6129432, -122.4821475)
-            _LOGGER.info('CDC data by latitude/longitude: %s', cdc_coord_resp)
+                LATITUDE, LONGITUDE)
+            _LOGGER.info(
+                'CDC data by latitude/longitude (%s, %s): %s', LATITUDE,
+                LONGITUDE, cdc_coord_resp)
 
             # Get CDC data for North Dakota
-            cdc_state_resp = await client.cdc_reports.status_by_state(
-                'North Dakota')
-            _LOGGER.info('CDC data by state name: %s', cdc_state_resp)
+            cdc_state_resp = await client.cdc_reports.status_by_state(STATE)
+            _LOGGER.info(
+                'CDC data by state name (%s): %s', STATE, cdc_state_resp)
         except FluNearYouError as err:
             print(err)
 

--- a/pyflunearyou/report.py
+++ b/pyflunearyou/report.py
@@ -1,6 +1,8 @@
 """Define a generic report object."""
 from typing import Callable, Coroutine
 
+from aiocache import cached
+
 
 class Report:  # pylint: disable=too-few-public-methods
     """Define a generic report object."""
@@ -13,3 +15,11 @@ class Report:  # pylint: disable=too-few-public-methods
         self._cache_seconds = cache_seconds
         self._get_raw_data = get_raw_data
         self._request = request
+
+        self.raw_state_data = cached(
+            ttl=self._cache_seconds, key='state_data')(
+                self._raw_state_data)
+
+    async def _raw_state_data(self) -> dict:
+        """Return the raw state data."""
+        return await self._get_raw_data('states')

--- a/pyflunearyou/user.py
+++ b/pyflunearyou/user.py
@@ -5,7 +5,7 @@ from typing import Callable, Coroutine
 from aiocache import cached
 
 from .report import Report
-from .util import haversine
+from .util import get_nearest_by_coordinates
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,34 +19,42 @@ class UserReport(Report):
             cache_seconds: int) -> None:
         """Initialize."""
         super().__init__(request, get_raw_data, cache_seconds)
-        self.raw_data = cached(ttl=self._cache_seconds)(self._raw_user_data)
+        self.raw_local_data = cached(ttl=self._cache_seconds)(
+            self._raw_local_data)
 
-    async def _raw_user_data(self) -> dict:
+    async def _raw_local_data(self) -> dict:
         """Return the raw user data."""
         return await self._get_raw_data('map/markers')
 
     async def status_by_coordinates(
             self, latitude: float, longitude: float) -> dict:
         """Get symptom data for the location nearest to the user's lat/lon."""
-        data = [
-            d for d in await self.raw_data()
-            if d['latitude'] and d['longitude']
+        data = {}
+
+        local_data = [
+            location for location in await self.raw_local_data()
+            if location['latitude'] and location['longitude']
         ]
-        closest = min(
-            data,
-            key=lambda p: haversine(
-                latitude,
-                longitude,
-                float(p['latitude']),
-                float(p['longitude'])
-            ))
-        return closest
+        data['local'] = get_nearest_by_coordinates(
+            local_data, 'latitude', 'longitude', latitude, longitude)
+
+        state_data = [
+            location for location in await self.raw_state_data()
+            if location['name'] != 'United States'
+        ]
+        data['state'] = get_nearest_by_coordinates(
+            state_data, 'lat', 'lon', latitude, longitude)
+
+        return data
 
     async def status_by_zip(self, zip_code: str) -> dict:
         """Get symptom data for the provided ZIP code."""
         try:
-            [info] = [d for d in await self.raw_data() if d['zip'] == zip_code]
-        except ValueError:
+            location = next((
+                d for d in await self.raw_local_data()
+                if d['zip'] == zip_code))
+        except StopIteration:
             return {}
 
-        return info
+        return await self.status_by_coordinates(
+            float(location['latitude']), float(location['longitude']))

--- a/pyflunearyou/util.py
+++ b/pyflunearyou/util.py
@@ -1,5 +1,21 @@
 """Define various utility functions."""
+from typing import Any
+
 from math import radians, cos, sin, asin, sqrt
+
+
+def get_nearest_by_coordinates(
+        data: list, latitude_key: str, longitude_key: str,
+        target_latitude: float, target_longitude: float) -> Any:
+    """Get the closest dict entry based on latitude/longitude."""
+    return min(
+        data,
+        key=lambda p: haversine(
+            target_latitude,
+            target_longitude,
+            float(p[latitude_key]),
+            float(p[longitude_key])
+        ))
 
 
 def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,4 +1,4 @@
 """Define constants for tests."""
 TEST_LATITUDE = 34.114731
 TEST_LONGITUDE = -118.363724
-TEST_ZIP = '97330'
+TEST_ZIP = '90046'

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -25,20 +25,62 @@ async def test_status_by_coordinates_success(
             TEST_LATITUDE, TEST_LONGITUDE)
 
         assert info == {
-            "id": 2,
-            "city": "Los Angeles(90046)",
-            "place_id": "23818",
-            "zip": "90046",
-            "contained_by": "204",
-            "latitude": "34.114731",
-            "longitude": "-118.363724",
-            "none": 2,
-            "symptoms": 0,
-            "flu": 0,
-            "lepto": 0,
-            "dengue": 0,
-            "chick": 0,
-            "icon": "1"
+            "local": {
+                "id": 2,
+                "city": "Los Angeles(90046)",
+                "place_id": "23818",
+                "zip": "90046",
+                "contained_by": "204",
+                "latitude": "34.114731",
+                "longitude": "-118.363724",
+                "none": 2,
+                "symptoms": 0,
+                "flu": 0,
+                "lepto": 0,
+                "dengue": 0,
+                "chick": 0,
+                "icon": "1"
+            },
+            "state": {
+                "name": "California",
+                "place_id": "204",
+                "lat": "37.250198",
+                "lon": "-119.750298",
+                "data": {
+                    "symptoms_percentage": 12.32,
+                    "none_percentage": 87.68,
+                    "ili_percentage": 2.69,
+                    "lepto_percentage": 0,
+                    "dengue_percentage": 2.17,
+                    "chick_percentage": 0,
+                    "level": 3,
+                    "overlay_color": "#00B7B6",
+                    "total_surveys": 2119,
+                    "symptoms": 261,
+                    "no_symptoms": 1858,
+                    "ili": 57,
+                    "lepto": 0,
+                    "dengue": 46,
+                    "chick": 0
+                },
+                "last_week_data": {
+                    "symptoms_percentage": 14.29,
+                    "none_percentage": 85.71,
+                    "ili_percentage": 2.91,
+                    "lepto_percentage": 0.05,
+                    "dengue_percentage": 2.21,
+                    "chick_percentage": 0,
+                    "level": 3,
+                    "overlay_color": "#00B7B6",
+                    "total_surveys": 2128,
+                    "symptoms": 304,
+                    "no_symptoms": 1824,
+                    "ili": 62,
+                    "lepto": 1,
+                    "dengue": 47,
+                    "chick": 0
+                }
+            }
         }
 
 
@@ -56,20 +98,62 @@ async def test_status_by_zip_success(
         info = await client.user_reports.status_by_zip(TEST_ZIP)
 
         assert info == {
-            "id": 3,
-            "city": "Corvallis(97330)",
-            "place_id": "21462",
-            "zip": "97330",
-            "contained_by": "239",
-            "latitude": "44.638504",
-            "longitude": "-123.292938",
-            "none": 3,
-            "symptoms": 0,
-            "flu": 0,
-            "lepto": 0,
-            "dengue": 0,
-            "chick": 0,
-            "icon": "1"
+            "local": {
+                "id": 2,
+                "city": "Los Angeles(90046)",
+                "place_id": "23818",
+                "zip": "90046",
+                "contained_by": "204",
+                "latitude": "34.114731",
+                "longitude": "-118.363724",
+                "none": 2,
+                "symptoms": 0,
+                "flu": 0,
+                "lepto": 0,
+                "dengue": 0,
+                "chick": 0,
+                "icon": "1"
+            },
+            "state": {
+                "name": "California",
+                "place_id": "204",
+                "lat": "37.250198",
+                "lon": "-119.750298",
+                "data": {
+                    "symptoms_percentage": 12.32,
+                    "none_percentage": 87.68,
+                    "ili_percentage": 2.69,
+                    "lepto_percentage": 0,
+                    "dengue_percentage": 2.17,
+                    "chick_percentage": 0,
+                    "level": 3,
+                    "overlay_color": "#00B7B6",
+                    "total_surveys": 2119,
+                    "symptoms": 261,
+                    "no_symptoms": 1858,
+                    "ili": 57,
+                    "lepto": 0,
+                    "dengue": 46,
+                    "chick": 0
+                },
+                "last_week_data": {
+                    "symptoms_percentage": 14.29,
+                    "none_percentage": 85.71,
+                    "ili_percentage": 2.91,
+                    "lepto_percentage": 0.05,
+                    "dengue_percentage": 2.21,
+                    "chick_percentage": 0,
+                    "level": 3,
+                    "overlay_color": "#00B7B6",
+                    "total_surveys": 2128,
+                    "symptoms": 304,
+                    "no_symptoms": 1824,
+                    "ili": 62,
+                    "lepto": 1,
+                    "dengue": 47,
+                    "chick": 0
+                }
+            }
         }
 
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR restructures and adds data to the `user_reports` endpoint:

* `client.user_reports.status_by_coordinates(...)` and `client.user_reports.status_by_zip(...)` will still return a `dict`.
* Local data (i.e., the data that the endpoint previously returned) will now live under a `local` key.
* Statewide data for that location will live under a `state` key.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)