### PR TITLE
Fix a bug with previously-unknown CDC ranges

### DIFF
--- a/pyflunearyou/cdc.py
+++ b/pyflunearyou/cdc.py
@@ -7,7 +7,8 @@ from typing import Callable, Coroutine, Dict  # noqa
 from aiocache import cached
 
 from .report import Report
-from .util import get_nearest_by_coordinates
+from .util import get_nearest_by_numeric_key
+from .util.geo import get_nearest_by_coordinates
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,9 +27,10 @@ def adjust_status(info: dict) -> dict:
     modified_info = deepcopy(info)
     modified_info.update({
         'level':
-            STATUS_MAP[int(info['level'])],
+            get_nearest_by_numeric_key(STATUS_MAP, int(info['level'])),
         'level2':
-            STATUS_MAP[int(99 if info['level2'] is None else info['level2'])],
+            STATUS_MAP[99] if info['level2'] is None else
+            get_nearest_by_numeric_key(STATUS_MAP, int(info['level2']))
     })
 
     return modified_info

--- a/pyflunearyou/user.py
+++ b/pyflunearyou/user.py
@@ -5,7 +5,7 @@ from typing import Callable, Coroutine
 from aiocache import cached
 
 from .report import Report
-from .util import get_nearest_by_coordinates
+from .util.geo import get_nearest_by_coordinates
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/pyflunearyou/util/__init__.py
+++ b/pyflunearyou/util/__init__.py
@@ -1,0 +1,7 @@
+"""Define various miscellaneous utility functions."""
+from typing import Any
+
+
+def get_nearest_by_numeric_key(data: dict, key: int) -> Any:
+    """Return the dict element whose numeric key is closest to a target."""
+    return data.get(key, data[min(data.keys(), key=lambda k: abs(k - key))])

--- a/pyflunearyou/util/geo.py
+++ b/pyflunearyou/util/geo.py
@@ -1,4 +1,4 @@
-"""Define various utility functions."""
+"""Define various geo utility functions."""
 from typing import Any
 
 from math import radians, cos, sin, asin, sqrt

--- a/tests/fixtures/cdc.py
+++ b/tests/fixtures/cdc.py
@@ -10,7 +10,7 @@ def fixture_cdc_report_json():
             "place_id": "204"
         },
         "California": {
-            "level": "3",
+            "level": "6",
             "level2": None,
             "week_date": "2018-10-13",
             "name": "California",

--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -29,7 +29,7 @@ async def test_status_by_coordinates_success(
             TEST_LATITUDE, TEST_LONGITUDE)
 
         assert info == {
-            "level": "Low",
+            "level": "High",
             "level2": "None",
             "week_date": "2018-10-13",
             "name": "California",


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes #7 by adjusting the CDC mapping logic to pick the nearest value, rather than choking on an unknown value. For example, `6` should return the same value as `5`, rather than throwing an exception.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pyflunearyou/issues/7
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
