### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/pyflunearyou/client.py
+++ b/pyflunearyou/client.py
@@ -1,5 +1,6 @@
 """Define a client to interact with Flu Near You."""
 import logging
+from typing import Optional
 
 from aiohttp import ClientSession, client_exceptions
 
@@ -7,14 +8,14 @@ from .cdc import CdcReport
 from .errors import RequestError
 from .user import UserReport
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER: logging.Logger = logging.getLogger(__name__)
 
-DEFAULT_CACHE_SECONDS = 60 * 60
-DEFAULT_HOST = "api.v2.flunearyou.org"
-DEFAULT_ORIGIN = "https://flunearyou.org"
-DEFAULT_USER_AGENT = "Home Assistant (Macintosh; OS X/10.14.0) GCDHTTPRequest"
+DEFAULT_CACHE_SECONDS: int = 60 * 60
+DEFAULT_HOST: str = "api.v2.flunearyou.org"
+DEFAULT_ORIGIN: str = "https://flunearyou.org"
+DEFAULT_USER_AGENT: str = "Home Assistant (Macintosh; OS X/10.14.0) GCDHTTPRequest"
 
-API_URL_SCAFFOLD = f"https://{DEFAULT_HOST}"
+API_URL_SCAFFOLD: str = f"https://{DEFAULT_HOST}"
 
 
 class Client:  # pylint: disable=too-few-public-methods
@@ -24,13 +25,13 @@ class Client:  # pylint: disable=too-few-public-methods
         self, websession: ClientSession, *, cache_seconds: int = DEFAULT_CACHE_SECONDS
     ) -> None:
         """Initialize."""
-        self._cache_seconds = cache_seconds
-        self._websession = websession
-        self.cdc_reports = CdcReport(self._request, cache_seconds)
-        self.user_reports = UserReport(self._request, cache_seconds)
+        self._cache_seconds: int = cache_seconds
+        self._websession: ClientSession = websession
+        self.cdc_reports: CdcReport = CdcReport(self._request, cache_seconds)
+        self.user_reports: UserReport = UserReport(self._request, cache_seconds)
 
     async def _request(
-        self, method: str, endpoint: str, *, headers: dict = None
+        self, method: str, endpoint: str, *, headers: Optional[dict] = None
     ) -> dict:
         """Make a request against Flu Near You."""
         if not headers:

--- a/pyflunearyou/helpers/geo.py
+++ b/pyflunearyou/helpers/geo.py
@@ -28,9 +28,9 @@ def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
 
     # haversine formula
-    dlon = lon2 - lon1
-    dlat = lat2 - lat1
-    calc_a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
-    calc_c = 2 * asin(sqrt(calc_a))
+    dlon: float = lon2 - lon1
+    dlat: float = lat2 - lat1
+    calc_a: float = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    calc_c: float = 2 * asin(sqrt(calc_a))
 
     return 6371 * calc_c

--- a/pyflunearyou/user.py
+++ b/pyflunearyou/user.py
@@ -3,7 +3,7 @@ import logging
 
 from .report import Report
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 class UserReport(Report):
@@ -16,7 +16,7 @@ class UserReport(Report):
     async def status_by_zip(self, zip_code: str) -> dict:
         """Get symptom data for the provided ZIP code."""
         try:
-            location = next(
+            location: dict = next(
                 (d for d in await self.user_reports() if d["zip"] == zip_code)
             )
         except StopIteration:


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
