### PR TITLE
Make aiothttp ClientSession optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
 `pyflunearyou` is a simple Python library for retrieving UV-related information
 from [Flu Near You](https://flunearyou.org/#!/).
 
+- [Installation](#installation)
+- [Python Versions](#python-versions)
+- [Usage](#usage)
+- [Contributing](#contributing)
+
 # Installation
 
 ```python
@@ -27,25 +32,38 @@ pip install pyflunearyou
 
 # Usage
 
-`pyflunearyou` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
 ```python
 import asyncio
 
 from aiohttp import ClientSession
 
+from pyflunearyou import Client
+
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      # YOUR CODE HERE
+    """Run!"""
+    client = Client()
 
+    # Get user data for a specific latitude/longitude:
+    await client.user_reports.status_by_coordinates(<LATITUDE>, <LONGITUDE>)
 
-asyncio.get_event_loop().run_until_complete(main())
+    # Get user data for a specific ZIP code:
+    await client.user_reports.status_by_zip("<ZIP_CODE>")
+
+    # Get CDC data for a specific latitude/longitude:
+    await client.cdc_reports.status_by_coordinates(<LATITUDE>, <LONGITUDE>)
+
+    # Get CDC data for a specific state:
+    await client.cdc_reports.status_by_state('<USA_CANADA_STATE_NAME>')
+
+asyncio.run(main())
 ```
 
-Create a client and get to work:
+By default, the library creates a new connection to Flu Near You with each coroutine. If
+you are calling a large number of coroutines (or merely want to squeeze out every second
+of runtime savings possible), an
+[`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection
+pooling:
 
 ```python
 import asyncio
@@ -56,23 +74,13 @@ from pyflunearyou import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      client = Client(websession)
+    """Run!"""
+    async with ClientSession() as session:
+        client = Client(session=session)
 
-      # Get user data for a specific latitude/longitude:
-      await client.user_reports.status_by_coordinates(<LATITUDE>, <LONGITUDE>)
+        # ...
 
-      # Get user data for a specific ZIP code:
-      await client.user_reports.status_by_zip("<ZIP_CODE>")
-
-      # Get CDC data for a specific latitude/longitude:
-      await client.cdc_reports.status_by_coordinates(<LATITUDE>, <LONGITUDE>)
-
-      # Get CDC data for a specific state:
-      await client.cdc_reports.status_by_state('<USA_CANADA_STATE_NAME>')
-
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
 # Contributing
@@ -81,7 +89,7 @@ asyncio.get_event_loop().run_until_complete(main())
   or [initiate a discussion on one](https://github.com/bachya/pyflunearyou/issues/new).
 2. [Fork the repository](https://github.com/bachya/pyflunearyou/fork).
 3. (_optional, but highly recommended_) Create a virtual environment: `python3 -m venv .venv`
-4. (_optional, but highly recommended_) Enter the virtual environment: `source ./venv/bin/activate`
+4. (_optional, but highly recommended_) Enter the virtual environment: `source ./.venv/bin/activate`
 5. Install the dev environment: `script/setup`
 6. Code your new feature or bug fix.
 7. Write tests that cover your new functionality.

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -18,10 +18,10 @@ ZIP_CODE = "98110"
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     logging.basicConfig(level=logging.INFO)
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         try:
             # Create a client:
-            client = Client(websession)
+            client = Client(session=session)
 
             # Get user data for the client's latitude/longitude:
             user_coord_resp = await client.user_reports.status_by_coordinates(
@@ -56,4 +56,4 @@ async def main() -> None:
             print(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/pyflunearyou/cdc.py
+++ b/pyflunearyou/cdc.py
@@ -6,7 +6,7 @@ from typing import Callable, Coroutine, Dict
 from aiocache import cached
 
 from .helpers import get_nearest_by_numeric_key
-from .report import Report
+from .helpers.report import Report
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/pyflunearyou/client.py
+++ b/pyflunearyou/client.py
@@ -2,7 +2,8 @@
 import logging
 from typing import Optional
 
-from aiohttp import ClientSession, client_exceptions
+from aiohttp import ClientSession, ClientTimeout
+from aiohttp.client_exceptions import ClientError
 
 from .cdc import CdcReport
 from .errors import RequestError
@@ -13,6 +14,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 DEFAULT_CACHE_SECONDS: int = 60 * 60
 DEFAULT_HOST: str = "api.v2.flunearyou.org"
 DEFAULT_ORIGIN: str = "https://flunearyou.org"
+DEFAULT_TIMEOUT: int = 10
 DEFAULT_USER_AGENT: str = "Home Assistant (Macintosh; OS X/10.14.0) GCDHTTPRequest"
 
 API_URL_SCAFFOLD: str = f"https://{DEFAULT_HOST}"
@@ -22,11 +24,14 @@ class Client:  # pylint: disable=too-few-public-methods
     """Define the client."""
 
     def __init__(
-        self, websession: ClientSession, *, cache_seconds: int = DEFAULT_CACHE_SECONDS
+        self,
+        *,
+        cache_seconds: int = DEFAULT_CACHE_SECONDS,
+        session: Optional[ClientSession] = None,
     ) -> None:
         """Initialize."""
         self._cache_seconds: int = cache_seconds
-        self._websession: ClientSession = websession
+        self._session: ClientSession = session
         self.cdc_reports: CdcReport = CdcReport(self._request, cache_seconds)
         self.user_reports: UserReport = UserReport(self._request, cache_seconds)
 
@@ -34,9 +39,8 @@ class Client:  # pylint: disable=too-few-public-methods
         self, method: str, endpoint: str, *, headers: Optional[dict] = None
     ) -> dict:
         """Make a request against Flu Near You."""
-        if not headers:
-            headers = {}
-        headers.update(
+        _headers = headers or {}
+        _headers.update(
             {
                 "Host": DEFAULT_HOST,
                 "Origin": DEFAULT_ORIGIN,
@@ -45,13 +49,23 @@ class Client:  # pylint: disable=too-few-public-methods
             }
         )
 
-        async with self._websession.request(
-            method, f"{API_URL_SCAFFOLD}/{endpoint}", headers=headers
-        ) as resp:
-            try:
+        use_running_session = self._session and not self._session.closed
+
+        if use_running_session:
+            session = self._session
+        else:
+            session = ClientSession(timeout=ClientTimeout(total=DEFAULT_TIMEOUT))
+
+        try:
+            async with session.request(
+                method, f"{API_URL_SCAFFOLD}/{endpoint}", headers=_headers
+            ) as resp:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
-            except client_exceptions.ClientError as err:
-                raise RequestError(
-                    f"Error requesting data from {endpoint}: {err}"
-                ) from None
+        except ClientError as err:
+            raise RequestError(
+                f"Error requesting data from {endpoint}: {err}"
+            ) from None
+        finally:
+            if not use_running_session:
+                await session.close()

--- a/pyflunearyou/helpers/report.py
+++ b/pyflunearyou/helpers/report.py
@@ -4,9 +4,12 @@ from typing import Callable, Coroutine
 
 from aiocache import cached
 
-from .helpers.geo import get_nearest_by_coordinates
+from .geo import get_nearest_by_coordinates
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+CACHE_KEY_LOCAL_DATA = "local_data"
+CACHE_KEY_STATE_DATA = "state_data"
 
 
 class Report:  # pylint: disable=too-few-public-methods
@@ -18,10 +21,10 @@ class Report:  # pylint: disable=too-few-public-methods
         self._request: Callable[..., Coroutine] = request
 
         self.user_reports: Callable[..., Coroutine] = cached(
-            ttl=self._cache_seconds, key="local_data"
+            ttl=self._cache_seconds, key=CACHE_KEY_LOCAL_DATA
         )(self._raw_user_report_data)
         self.state_data: Callable[..., Coroutine] = cached(
-            ttl=self._cache_seconds, key="state_data"
+            ttl=self._cache_seconds, key=CACHE_KEY_STATE_DATA
         )(self._raw_state_data)
 
     async def _raw_user_report_data(self) -> list:

--- a/pyflunearyou/user.py
+++ b/pyflunearyou/user.py
@@ -1,7 +1,7 @@
 """Define endpoints related to user reports."""
 import logging
 
-from .report import Report
+from .helpers.report import Report
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,6 @@ ujson = ">=1.35,<3.0"
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"
 pre-commit = "^2.0.1"
-pytest = "^5.3.5"
+pytest = "^5.4.1"
 pytest-aiohttp = "^0.3.0"
 pytest-cov = "^2.8.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,4 @@ aiohttp==3.6.2
 aresponses==1.1.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
-pytest==5.3.5
+pytest==5.4.1

--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -1,8 +1,10 @@
 """Define tests for the CDC endpoints."""
+from aiocache import SimpleMemoryCache
 import aiohttp
 import pytest
 
 from pyflunearyou import Client
+from pyflunearyou.helpers.report import CACHE_KEY_LOCAL_DATA, CACHE_KEY_STATE_DATA
 
 from .common import TEST_LATITUDE, TEST_LONGITUDE, load_fixture
 
@@ -10,6 +12,10 @@ from .common import TEST_LATITUDE, TEST_LONGITUDE, load_fixture
 @pytest.mark.asyncio
 async def test_status_by_coordinates_success(aresponses):
     """Test getting CDC reports by latitude/longitude."""
+    cache = SimpleMemoryCache()
+    await cache.delete(CACHE_KEY_LOCAL_DATA)
+    await cache.delete(CACHE_KEY_STATE_DATA)
+
     aresponses.add(
         "api.v2.flunearyou.org",
         "/map/markers",
@@ -29,8 +35,8 @@ async def test_status_by_coordinates_success(aresponses):
         aresponses.Response(text=load_fixture("cdc_report_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         info = await client.cdc_reports.status_by_coordinates(
             TEST_LATITUDE, TEST_LONGITUDE
         )
@@ -43,8 +49,13 @@ async def test_status_by_coordinates_success(aresponses):
         }
 
 
+@pytest.mark.asyncio
 async def test_status_by_state_success(aresponses):
     """Test getting CDC reports by state."""
+    cache = SimpleMemoryCache()
+    await cache.delete(CACHE_KEY_LOCAL_DATA)
+    await cache.delete(CACHE_KEY_STATE_DATA)
+
     aresponses.add(
         "api.v2.flunearyou.org",
         "/map/markers",
@@ -64,8 +75,8 @@ async def test_status_by_state_success(aresponses):
         aresponses.Response(text=load_fixture("cdc_report_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         info = await client.cdc_reports.status_by_state("Colorado")
         assert info == {
             "level": "Minimal",
@@ -76,8 +87,13 @@ async def test_status_by_state_success(aresponses):
         }
 
 
+@pytest.mark.asyncio
 async def test_status_by_state_failure(aresponses):
     """Test getting CDC reports by state."""
+    cache = SimpleMemoryCache()
+    await cache.delete(CACHE_KEY_LOCAL_DATA)
+    await cache.delete(CACHE_KEY_STATE_DATA)
+
     aresponses.add(
         "api.v2.flunearyou.org",
         "/states",
@@ -91,7 +107,7 @@ async def test_status_by_state_failure(aresponses):
         aresponses.Response(text=load_fixture("cdc_report_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         info = await client.cdc_reports.status_by_state("Jupiter")
         assert info == {}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,18 +5,10 @@ import pytest
 from pyflunearyou import Client
 from pyflunearyou.errors import RequestError
 
-from .common import load_fixture
-
 
 @pytest.mark.asyncio
 async def test_request_error(aresponses):
     """Test that a bad API endpoint raises the correct exception."""
-    aresponses.add(
-        "api.v2.flunearyou.org",
-        "/map/markers",
-        "get",
-        aresponses.Response(text=load_fixture("user_report_response.json"), status=200),
-    )
     aresponses.add(
         "api.v2.flunearyou.org",
         "/bad/endpoint",
@@ -25,6 +17,8 @@ async def test_request_error(aresponses):
     )
 
     with pytest.raises(RequestError):
-        async with aiohttp.ClientSession() as websession:
-            client = Client(websession)
-            await client._request("get", "bad/endpoint")
+        async with aiohttp.ClientSession() as session:
+            client = Client(session=session)
+            await client._request(  # pylint: disable=protected-access
+                "get", "bad/endpoint"
+            )

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,8 +1,10 @@
 """Define tests for the user report endpoints."""
+from aiocache import SimpleMemoryCache
 import aiohttp
 import pytest
 
 from pyflunearyou import Client
+from pyflunearyou.helpers.report import CACHE_KEY_LOCAL_DATA, CACHE_KEY_STATE_DATA
 
 from .common import (
     TEST_LATITUDE,
@@ -15,17 +17,111 @@ from .common import (
 
 
 @pytest.mark.asyncio
-async def test_status_by_coordinates_success_id(aresponses):
-    """Test getting user reports by latitude/longitude (contained ID)."""
+async def test_no_explicit_client_session(aresponses):
+    """Test not providing an explicit aiohttp ClientSession."""
+    cache = SimpleMemoryCache()
+    await cache.delete(CACHE_KEY_LOCAL_DATA)
+    await cache.delete(CACHE_KEY_STATE_DATA)
+
     aresponses.add(
         "api.v2.flunearyou.org",
         "/map/markers",
         "get",
         aresponses.Response(text=load_fixture("user_report_response.json"), status=200),
     )
+    aresponses.add(
+        "api.v2.flunearyou.org",
+        "/states",
+        "get",
+        aresponses.Response(text=load_fixture("states_response.json"), status=200),
+    )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    client = Client()
+    info = await client.user_reports.status_by_coordinates(
+        TEST_LATITUDE, TEST_LONGITUDE
+    )
+    assert info == {
+        "local": {
+            "id": 2,
+            "city": "Los Angeles(90046)",
+            "place_id": "23818",
+            "zip": "90046",
+            "contained_by": "204",
+            "latitude": "34.114731",
+            "longitude": "-118.363724",
+            "none": 2,
+            "symptoms": 0,
+            "flu": 0,
+            "lepto": 0,
+            "dengue": 0,
+            "chick": 0,
+            "icon": "1",
+        },
+        "state": {
+            "name": "California",
+            "place_id": "204",
+            "lat": "37.250198",
+            "lon": "-119.750298",
+            "data": {
+                "symptoms_percentage": 12.32,
+                "none_percentage": 87.68,
+                "ili_percentage": 2.69,
+                "lepto_percentage": 0,
+                "dengue_percentage": 2.17,
+                "chick_percentage": 0,
+                "level": 3,
+                "overlay_color": "#00B7B6",
+                "total_surveys": 2119,
+                "symptoms": 261,
+                "no_symptoms": 1858,
+                "ili": 57,
+                "lepto": 0,
+                "dengue": 46,
+                "chick": 0,
+            },
+            "last_week_data": {
+                "symptoms_percentage": 14.29,
+                "none_percentage": 85.71,
+                "ili_percentage": 2.91,
+                "lepto_percentage": 0.05,
+                "dengue_percentage": 2.21,
+                "chick_percentage": 0,
+                "level": 3,
+                "overlay_color": "#00B7B6",
+                "total_surveys": 2128,
+                "symptoms": 304,
+                "no_symptoms": 1824,
+                "ili": 62,
+                "lepto": 1,
+                "dengue": 47,
+                "chick": 0,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_status_by_coordinates_success_id(aresponses):
+    """Test getting user reports by latitude/longitude (contained ID)."""
+    cache = SimpleMemoryCache()
+    await cache.delete(CACHE_KEY_LOCAL_DATA)
+    await cache.delete(CACHE_KEY_STATE_DATA)
+
+    aresponses.add(
+        "api.v2.flunearyou.org",
+        "/map/markers",
+        "get",
+        aresponses.Response(text=load_fixture("user_report_response.json"), status=200),
+    )
+    aresponses.add(
+        "api.v2.flunearyou.org",
+        "/states",
+        "get",
+        aresponses.Response(text=load_fixture("states_response.json"), status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         info = await client.user_reports.status_by_coordinates(
             TEST_LATITUDE, TEST_LONGITUDE
         )
@@ -92,15 +188,25 @@ async def test_status_by_coordinates_success_id(aresponses):
 @pytest.mark.asyncio
 async def test_status_by_coordinates_success_measure(aresponses):
     """Test getting user reports by latitude/longitude (measurement)."""
+    cache = SimpleMemoryCache()
+    await cache.delete(CACHE_KEY_LOCAL_DATA)
+    await cache.delete(CACHE_KEY_STATE_DATA)
+
     aresponses.add(
         "api.v2.flunearyou.org",
         "/map/markers",
         "get",
         aresponses.Response(text=load_fixture("user_report_response.json"), status=200),
     )
+    aresponses.add(
+        "api.v2.flunearyou.org",
+        "/states",
+        "get",
+        aresponses.Response(text=load_fixture("states_response.json"), status=200),
+    )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         info = await client.user_reports.status_by_coordinates(
             TEST_LATITUDE_UNCONTAINED, TEST_LONGITUDE_UNCONTAINED
         )
@@ -167,15 +273,25 @@ async def test_status_by_coordinates_success_measure(aresponses):
 @pytest.mark.asyncio
 async def test_status_by_zip_success(aresponses):
     """Test getting user reports by ZIP code."""
+    cache = SimpleMemoryCache()
+    await cache.delete(CACHE_KEY_LOCAL_DATA)
+    await cache.delete(CACHE_KEY_STATE_DATA)
+
     aresponses.add(
         "api.v2.flunearyou.org",
         "/map/markers",
         "get",
         aresponses.Response(text=load_fixture("user_report_response.json"), status=200),
     )
+    aresponses.add(
+        "api.v2.flunearyou.org",
+        "/states",
+        "get",
+        aresponses.Response(text=load_fixture("states_response.json"), status=200),
+    )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         info = await client.user_reports.status_by_zip(TEST_ZIP)
         assert info == {
             "local": {
@@ -240,14 +356,24 @@ async def test_status_by_zip_success(aresponses):
 @pytest.mark.asyncio
 async def test_status_by_zip_failure(aresponses):
     """Test getting user reports by ZIP code."""
+    cache = SimpleMemoryCache()
+    await cache.delete(CACHE_KEY_LOCAL_DATA)
+    await cache.delete(CACHE_KEY_STATE_DATA)
+
     aresponses.add(
         "api.v2.flunearyou.org",
         "/map/markers",
         "get",
         aresponses.Response(text=load_fixture("user_report_response.json"), status=200),
     )
+    aresponses.add(
+        "api.v2.flunearyou.org",
+        "/states",
+        "get",
+        aresponses.Response(text=load_fixture("states_response.json"), status=200),
+    )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         info = await client.user_reports.status_by_zip("00000")
         assert info == {}


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes the `aiohttp` `ClientSession` an optional parameter when creating an API object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
