### PR TITLE
Bump ujson to a minimum of 5.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ aiocache = "^0.11.1"
 aiohttp = ">=3.8.0"
 msgpack = ">=0.6.2,<1.1.0"
 python = "^3.7.0"
-ujson = ">=5.1"
+ujson = ">=5.4.0"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"


### PR DESCRIPTION
**Describe what the PR does:**

This PR sets a minimum version for `ujson` to 5.4.0.

**Does this fix a specific issue?**

Fixes #79
Fixes #80 

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
